### PR TITLE
[Fix] Bug where the list disappears when the status changes

### DIFF
--- a/EnglishWordGenerator.xcodeproj/project.pbxproj
+++ b/EnglishWordGenerator.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		26F5FFBD2843DC2200C14D69 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26F5FFBC2843DC2200C14D69 /* Assets.xcassets */; };
 		26F5FFC02843DC2200C14D69 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26F5FFBF2843DC2200C14D69 /* Preview Assets.xcassets */; };
 		26F5FFC72843DC4700C14D69 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F5FFC62843DC4700C14D69 /* MainView.swift */; };
-		26F5FFC92843DCD700C14D69 /* SecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F5FFC82843DCD700C14D69 /* SecondView.swift */; };
+		26F5FFC92843DCD700C14D69 /* WordGeneratingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F5FFC82843DCD700C14D69 /* WordGeneratingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,7 +22,7 @@
 		26F5FFBC2843DC2200C14D69 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		26F5FFBF2843DC2200C14D69 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		26F5FFC62843DC4700C14D69 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
-		26F5FFC82843DCD700C14D69 /* SecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondView.swift; sourceTree = "<group>"; };
+		26F5FFC82843DCD700C14D69 /* WordGeneratingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordGeneratingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,7 +58,7 @@
 				26F5FFB82843DC2000C14D69 /* EnglishWordGeneratorApp.swift */,
 				26C0D5B92847B850009CE570 /* NetworkManager.swift */,
 				26F5FFC62843DC4700C14D69 /* MainView.swift */,
-				26F5FFC82843DCD700C14D69 /* SecondView.swift */,
+				26F5FFC82843DCD700C14D69 /* WordGeneratingView.swift */,
 				26F5FFBC2843DC2200C14D69 /* Assets.xcassets */,
 				26F5FFBE2843DC2200C14D69 /* Preview Content */,
 			);
@@ -145,7 +145,7 @@
 			files = (
 				26F5FFC72843DC4700C14D69 /* MainView.swift in Sources */,
 				26C0D5BA2847B850009CE570 /* NetworkManager.swift in Sources */,
-				26F5FFC92843DCD700C14D69 /* SecondView.swift in Sources */,
+				26F5FFC92843DCD700C14D69 /* WordGeneratingView.swift in Sources */,
 				26F5FFB92843DC2000C14D69 /* EnglishWordGeneratorApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EnglishWordGenerator/MainView.swift
+++ b/EnglishWordGenerator/MainView.swift
@@ -14,8 +14,10 @@ struct MainView: View {
         NavigationView {
             VStack {
                 Text("Choose a number between 1 and 15.")
+                
                 Stepper(value: $numberOfWord, in: 1...15, step: 1, label: { Text("\(numberOfWord)개") })
-                NavigationLink(destination: { SecondView(numberOfWord: $numberOfWord) }, label: {
+                
+                NavigationLink(destination: { WordGeneratingView(numberOfWord: $numberOfWord) }, label: {
                     Text("Generate")
                 })
             }

--- a/EnglishWordGenerator/MainView.swift
+++ b/EnglishWordGenerator/MainView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MainView: View {
-    @ObservedObject var networkManager = NetworkManager()
     @State private var numberOfWord: Int = 10
     
     var body: some View {
@@ -20,7 +19,7 @@ struct MainView: View {
                     Text("Generate")
                 })
             }
+            .padding(.horizontal, 16)
         }
-        .padding(.horizontal, 16)
     }
 }

--- a/EnglishWordGenerator/NetworkManager.swift
+++ b/EnglishWordGenerator/NetworkManager.swift
@@ -12,7 +12,7 @@ class NetworkManager: ObservableObject {
     
     let urlString = "https://random-word-api.herokuapp.com/word"
     
-    func getData(number: Int) {
+    func requestWordList(number: Int) {
         var urlComponents = URLComponents(string: urlString)
         let numberQuery = URLQueryItem(name: "number", value: "\(number)")
         urlComponents?.queryItems = [numberQuery]

--- a/EnglishWordGenerator/SecondView.swift
+++ b/EnglishWordGenerator/SecondView.swift
@@ -7,20 +7,8 @@
 
 import SwiftUI
 
-struct WordCard: View {
-    var word: String
-    
-    var body: some View {
-        Text(word)
-            .frame(maxWidth: .infinity, maxHeight: 300)
-            .background(RoundedRectangle(cornerRadius: 10)
-                .fill(Color.white)
-                .shadow(color: Color.black.opacity(0.15), radius: 30, x: 0, y: 0))
-    }
-}
-
 struct SecondView: View {
-    @ObservedObject var networkManager = NetworkManager()
+    @StateObject var networkManager = NetworkManager()
     @Binding var numberOfWord: Int
     
     var body: some View {
@@ -32,25 +20,13 @@ struct SecondView: View {
             }, label: {
                 Text("Re-Generate")
             })
+            
             List(networkManager.wordList, id: \.self) { word in
                 Text(word)
             }
             .onAppear {
                 networkManager.getData(number: numberOfWord)
             }
-            
-//            ScrollView(.horizontal) {
-//                HStack {
-//                    ForEach(networkManager.wordList, id: \.self) { word in
-//                        WordCard(word: word)
-//                    }
-//                }
-//                .padding(16)
-//            }
-//            .onAppear {
-//                networkManager.getData(number: numberOfWord)
-//            }
         }
-//        .padding(.horizontal, 16)
     }
 }

--- a/EnglishWordGenerator/WordGeneratingView.swift
+++ b/EnglishWordGenerator/WordGeneratingView.swift
@@ -1,5 +1,5 @@
 //
-//  SecondView.swift
+//  WordGeneratingViewView.swift
 //  EnglishWordGenerator
 //
 //  Created by 김민택 on 2022/05/30.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SecondView: View {
+struct WordGeneratingView: View {
     @StateObject var networkManager = NetworkManager()
     @Binding var numberOfWord: Int
     
@@ -15,8 +15,9 @@ struct SecondView: View {
         VStack {
             Stepper(value: $numberOfWord, in: 1...15, step: 1, label: { Text("\(numberOfWord)개") })
                 .padding(.horizontal, 16)
+            
             Button(action: {
-                networkManager.getData(number: numberOfWord)
+                networkManager.requestWordList(number: numberOfWord)
             }, label: {
                 Text("Re-Generate")
             })
@@ -25,7 +26,7 @@ struct SecondView: View {
                 Text(word)
             }
             .onAppear {
-                networkManager.getData(number: numberOfWord)
+                networkManager.requestWordList(number: numberOfWord)
             }
         }
     }


### PR DESCRIPTION
## 작업 내역

- `Stepper`를 사용하여 `numberOfWord`의 값을 변경했을 때, 리스트가 사라지는 버그 수정
  - `SecondView`에서 `@ObservedObject`로 불러와지던 `NetworkManager` class를 `@StateObject`로 불러오는 것으로 변경하여 다른 `@State` 값이 변경되어도 `NetworkManager`가 초기화되지 않도록 수정하였습니다.
- 미사용 코드 삭제
  - `MainView`에서 사용되지 않는 `NetworkManager`를 삭제했습니다.
  - 더 이상 사용되지 않는 `WordCard` View를 삭제했습니다.
  - `SecondView`에서 더 이상 사용되지 않는 `ScrollView`를 삭제했습니다.

### 추가 작업 내역
- 직관적이지 못한 네이밍 수정
  - 목적을 알 수 없는 뷰 이름 `SecondView`를 `WordGeneratingView`로 변경했습니다.
  - `NetworkManager`의 직관적이지 못한 함수 이름 `getData`를 `requestWordList`로 변경했습니다.
- 기타 수정 내역
  - 코드를 더 쉽게 볼 수 있도록 코드간에 간격을 추가했습니다.